### PR TITLE
Broaden offense string match

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -87,7 +87,7 @@ func runRubocop(cookbookPath string) (int, error) {
 	cmd.Env = []string{"HOME=" + cfg.Default.Tempdir}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		if strings.Contains(string(output), "offenses detected") {
+		if strings.Contains(string(output), "offense") {
 			errText := strings.TrimSpace(strings.Replace(string(output), fmt.Sprintf("%s/", cookbookPath), "", -1))
 			return http.StatusPreconditionFailed, fmt.Errorf("\n=== Rubocop errors found ===\n%s\n============================\n", errText)
 		} else {


### PR DESCRIPTION
Fix the case when there's only one offense found.

Currently it doesn't match `1 offense detected` and returns 502:

```
ERROR:   2015/03/12 18:41:42 Failed to execute rubocop tests: Inspecting 1 file
C

Offenses:

var/tmp/chef-guard/cookbook/attributes/default.rb:7:1: C: 1 trailing blank lines detected.

1 file inspected, 1 offense detected
 - exit status 1

✗ knife cookbook upload cookbook --freeze
Uploading cookbook    [0.1.46]
ERROR: Server returned error 502 for https://chef/cookbooks/cookbook/0.1.46, retrying 1/5 in 4s
```

Could also use regex to match `offense[s]? found`, but I think matching "offense" should be fine.
