### PR TITLE
Provide build guide for MacOSX

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -7,9 +7,26 @@ Just as a heads up, building the project is actually as easy as running `go buil
 
 All dependencies are vendored in using '[godep save -r](https://github.com/tools/godep)' so all imports are rewritten to their current, vendored location. I'm currently working on a tweak for goimports so it also supports using with vendored projects. More to come on that later on.
 
-## Building Chef-Guard
+## Building Chef-Guard on Linux
 
-I cannot make it any easier that just using this one command: `go build` in the source directory :) For more information and details you should really checkout the Chef-Guard [project page](http://xanzy.io/projects/chef-guard) at [Xanzy](http://xanzy.io) which contains just about all the info you need to get started...
+I cannot make it any easier that just using this one command: `go build` in the source directory :)
+
+## Building Chef-Guard on MacOSX
+### Prerequisites
+
+Be sure to install Go to be able to crosscompile:
+```
+$ brew install go --cross-compile-common
+```
+
+### Compilation
+
+Provide an OS to compile for:
+```
+$ GOOS=linux go build
+```
+
+For more information and details you should really checkout the Chef-Guard [project page](http://xanzy.io/projects/chef-guard) at [Xanzy](http://xanzy.io) which contains just about all the info you need to get started...
 
 ## Contributing
 


### PR DESCRIPTION
It's a common case when people develop on MacOSX workstation and use Linux as server OS.
Providing additional docs on compiling CG for MacOSX will allow more people to contribute.

Especially considering weird errors you're getting when not providing "GOOS=linux" and trying to start CG:

```
/opt/chef-guard/chef-guard: 1: /opt/chef-guard/chef-guard: Syntax error: "(" unexpected
```
