### PR TITLE
Fix a Gitlab bug and add additional Gitlab support

### DIFF
--- a/git.go
+++ b/git.go
@@ -23,6 +23,7 @@ import (
 	"net/smtp"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/xanzy/chef-guard/git"
 	"github.com/xanzy/multisyncer"
@@ -37,6 +38,9 @@ func (cg *ChefGuard) syncedGitUpdate(action string, body []byte) {
 
 	ms.Lock(cg.Repo)
 	defer ms.Unlock(cg.Repo)
+
+	// Once we get the lock, we wait for 500ms to prevent DDOS'ing the Git backend.
+	time.Sleep(1 * time.Second)
 
 	config, err := remarshalConfig(action, body)
 	if err != nil {

--- a/git/github.go
+++ b/git/github.go
@@ -265,5 +265,6 @@ func (g *GitHub) UntagRepo(repo, tag string) error {
 		}
 		return fmt.Errorf("Error deleting tag %s: %v", tag, err)
 	}
+
 	return nil
 }

--- a/validations.go
+++ b/validations.go
@@ -119,17 +119,17 @@ func (cg *ChefGuard) validateCookbookStatus() (int, error) {
 					"or, if you really need to change something, make a fork and\n"+
 					"and create a pull request back to the community cookbook\n"+
 					"before trying to upload the cookbook again.\n"+
-					"=====================================\n", err, cg.SourceCookbook.sourceURL)
+					"=====================================\n", err, strings.Split(cg.SourceCookbook.DownloadURL.String(), "&")[0])
 			case "git":
 				err = fmt.Errorf("\n=== Cookbook Compare errors found ===\n"+
 					"%s\n\nSource: %s\n\n"+
 					"Make sure all your changes are merged into the central\n"+
 					"repositories before trying to upload the cookbook again.\n"+
-					"=====================================\n", err, cg.SourceCookbook.sourceURL)
+					"=====================================\n", err, strings.Split(cg.SourceCookbook.DownloadURL.String(), "&")[0])
 			default:
 				err = fmt.Errorf("\n=== Cookbook Compare errors found ===\n"+
 					"%s\n\nSource: %s\n"+
-					"=====================================\n", err, cg.SourceCookbook.sourceURL)
+					"=====================================\n", err, strings.Split(cg.SourceCookbook.DownloadURL.String(), "&")[0])
 			}
 		}
 		return errCode, err
@@ -318,13 +318,13 @@ func (cg *ChefGuard) getSourceFileHashes() (map[string][16]byte, error) {
 	resp, err := client.Get(cg.SourceCookbook.DownloadURL.String())
 	if err != nil {
 		return nil, fmt.Errorf(
-			"Failed to download the cookbook from %s: %s", cg.SourceCookbook.sourceURL, err)
+			"Failed to download the cookbook from %s: %s", strings.Split(cg.SourceCookbook.DownloadURL.String(), "&")[0], err)
 	}
 	defer resp.Body.Close()
 
 	if err := checkHTTPResponse(resp, []int{http.StatusOK}); err != nil {
 		return nil, fmt.Errorf(
-			"Failed to download the cookbook from %s: %s", cg.SourceCookbook.sourceURL, err)
+			"Failed to download the cookbook from %s: %s", strings.Split(cg.SourceCookbook.DownloadURL.String(), "&")[0], err)
 	}
 
 	var tr *tar.Reader


### PR DESCRIPTION
Change the way to retrieve the diff, to prevent a panic (slice out of bound).

Also add the remaining Gitlab features that were missing when we first implemented Gitlab support, but are now supported by the Gitlab API.
