### PR TITLE
adding an uploaded field to cookbook json

### DIFF
--- a/cookbook.go
+++ b/cookbook.go
@@ -296,12 +296,13 @@ func (cg *ChefGuard) getCookbookChangeDetails(r *http.Request) []byte {
 	}
 
 	details := fmt.Sprintf(
-		"{\"name\":\"%s\",\"version\":\"%s\",\"frozen\":%t,\"forcedupload\":%t,\"source\":\"%s\"}",
+		"{\"name\":\"%s\",\"version\":\"%s\",\"frozen\":%t,\"forcedupload\":%t,\"source\":\"%s\", \"uploaded\": \"%s\"}",
 		v["name"],
 		v["version"],
 		frozen,
 		cg.ForcedUpload,
 		source,
+		time.Now().Format("2006-01-02 15:04:05"),
 	)
 
 	return []byte(details)


### PR DESCRIPTION
This changes adds an `uploaded` field to the cookbook JSON that gets
pushed. We would like this field since we sometimes have folks that forget
to bump the cookbook versions and upload the cookbook to the chef server.
In this case, because there is no change to the JSON, no commit is created
in the git repo so no event is fired off from a github webhook.

This ensures that for every `knife cookbook upload`, chef guard will be
able to commit *something* to git.