### PR TITLE
We should not touch the content of the files

### DIFF
--- a/cookbook.go
+++ b/cookbook.go
@@ -149,9 +149,6 @@ func (cg *ChefGuard) processCookbookFiles() error {
 			return fmt.Errorf("Failed to dowload %s from the %s cookbook: %s", f.Path, cg.Cookbook.Name, err)
 		}
 
-		// Make sure we only have unix style line endings
-		content = []byte(strings.Replace(string(content), "\r\n", "\n", -1))
-
 		if err := writeFileToDisk(path.Join(cg.CookbookPath, f.Path), strings.NewReader(string(content))); err != nil {
 			return fmt.Errorf("Failed to write file %s to disk: %s", path.Join(cg.CookbookPath, f.Path), err)
 		}

--- a/validations.go
+++ b/validations.go
@@ -124,7 +124,8 @@ func (cg *ChefGuard) validateCookbookStatus() (int, error) {
 				err = fmt.Errorf("\n=== Cookbook Compare errors found ===\n"+
 					"%s\n\nSource: %s\n\n"+
 					"Make sure all your changes are merged into the central\n"+
-					"repositories before trying to upload the cookbook again.\n"+
+					"repositories before trying to upload the cookbook again.\n\n"+
+					"HINT: Also double check your line endings (CRLF vs LF)!\n"+
 					"=====================================\n", err, strings.Split(cg.SourceCookbook.DownloadURL.String(), "&")[0])
 			default:
 				err = fmt.Errorf("\n=== Cookbook Compare errors found ===\n"+
@@ -364,9 +365,6 @@ func (cg *ChefGuard) getSourceFileHashes() (map[string][16]byte, error) {
 			if file == "chefignore" {
 				cg.ChefIgnoreFile = content
 			}
-
-			// Make sure we only have unix style line endings
-			content = []byte(strings.Replace(string(content), "\r\n", "\n", -1))
 
 			files[file] = md5.Sum(content)
 		}


### PR DESCRIPTION
This fixes #107 where we found corrupted binaries in cookbooks that Chef-Guard pushed to the supermarket.

At the same time it reverts the fix for issue #72. So to accomodate for issues mentioned in that issue, we extended the error message so it points out CRLF vs LF differences could cause the diff.

To solve these types of compare errors you probably need to add something like this to your git config:

```
Checkout Unix-style, commit Unix-style line endings
```