### PR TITLE
Change response when cookbook is frozen

### DIFF
--- a/validations.go
+++ b/validations.go
@@ -74,7 +74,7 @@ func (cg *ChefGuard) checkCookbookFrozen() (int, error) {
 		return http.StatusBadRequest, err
 	}
 	if frozen {
-		return http.StatusPreconditionFailed, fmt.Errorf("\n=== Cookbook Upload error found ===\n" +
+		return http.StatusConflict, fmt.Errorf("\n=== Cookbook Upload error found ===\n" +
 			"The cookbook you are trying to upload is frozen!\n" +
 			"It is not allowed to overwrite a frozen cookbook,\n" +
 			"so please bump the version and try again.\n" +


### PR DESCRIPTION
With Berkshelf 7.x the tool switched from using Ridley to using the Chef client libraries for communicating with the server. This introduced a change in behaviour when uploading cookbooks.

Where Ridley checks if a cookbook is frozen before uploading, the Chef libraries upload and check for a HTTP 409. At the moment Chef Guard returns a 412 error code when the cookbook is frozen.

It looks like this was reintroduced in release 0.6.0 with https://github.com/xanzy/chef-guard/commit/d37cdf3d06a860148e26ef1ada2300ebdffaf1b3, and it was originally fixed for release 0.4.4 with https://github.com/xanzy/chef-guard/commit/e614c329b58d4df232d6e67c1d033fad66c0f59f.

This PR changes the response back to 409 which makes Berkshelf 7 determine correctly when a cookbook is already frozen. It is compatible with older Berkshelf versions and with `knife`.

Signed-off-by: Kristian Vlaardingerbroek <kvlaardingerbroek@schubergphilis.com>