### PR TITLE
Patching Chef-Guard to work with Gitlab 11.4.10

### DIFF
--- a/git/gitlab.go
+++ b/git/gitlab.go
@@ -230,7 +230,7 @@ func (g *GitLab) GetDiff(project, user, sha string) (string, error) {
 
 // GetArchiveLink implements the Git interface
 func (g *GitLab) GetArchiveLink(project, tag string) (*url.URL, error) {
-	ns := fmt.Sprintf("%s/%s", g.group, project)
+	ns := fmt.Sprintf("%s%2F%s", g.group, project)
 
 	_, resp, err := g.client.Projects.GetProject(ns)
 	if err != nil {
@@ -246,7 +246,7 @@ func (g *GitLab) GetArchiveLink(project, tag string) (*url.URL, error) {
 	}
 
 	u, err := url.Parse(
-		fmt.Sprintf("/%s/repository/archive.tar.gz?ref=%s&private_token=%s",
+		fmt.Sprintf("/api/v4/projects/%s/repository/archive.tar.gz?ref=%s&private_token=%s",
 			ns,
 			tag,
 			g.token,

--- a/git/gitlab.go
+++ b/git/gitlab.go
@@ -230,7 +230,7 @@ func (g *GitLab) GetDiff(project, user, sha string) (string, error) {
 
 // GetArchiveLink implements the Git interface
 func (g *GitLab) GetArchiveLink(project, tag string) (*url.URL, error) {
-	ns := fmt.Sprintf("%s%2F%s", g.group, project)
+	ns := fmt.Sprintf("%s/%s", g.group, project)
 
 	_, resp, err := g.client.Projects.GetProject(ns)
 	if err != nil {
@@ -247,7 +247,7 @@ func (g *GitLab) GetArchiveLink(project, tag string) (*url.URL, error) {
 
 	u, err := url.Parse(
 		fmt.Sprintf("/api/v4/projects/%s/repository/archive.tar.gz?ref=%s&private_token=%s",
-			ns,
+			url.QueryEscape(ns),
 			tag,
 			g.token,
 		),

--- a/git/gitlab.go
+++ b/git/gitlab.go
@@ -246,7 +246,7 @@ func (g *GitLab) GetArchiveLink(project, tag string) (*url.URL, error) {
 	}
 
 	u, err := url.Parse(
-		fmt.Sprintf("/api/v4/projects/%s/repository/archive.tar.gz?ref=%s&private_token=%s",
+		fmt.Sprintf("projects/%s/repository/archive.tar.gz?sha=%s&private_token=%s",
 			url.QueryEscape(ns),
 			tag,
 			g.token,


### PR DESCRIPTION
Fixes chef guard to use the API to download cookbooks

From:
https://sbp.gitlab.schubergphilis.com/$GROUP/$PROJECT/repository/archive.tar.gz

To:
https://sbp.gitlab.schubergphilis.com/api/v4/projects/$GROUP%2F$PROJECT/repository/archive.tar.gz